### PR TITLE
createtables: add theme and nav_mode fields to project_meta

### DIFF
--- a/src/main/resources/tels/wise4-createtables.sql
+++ b/src/main/resources/tels/wise4-createtables.sql
@@ -365,6 +365,8 @@
         tools varchar(255),
         total_time varchar(255),
         version_id varchar(255),
+        nav_mode varchar(50),
+        theme varchar(50),
         primary key (id)
     ) engine=MyISAM;
 


### PR DESCRIPTION
This is a tiny patch to update to the wise4-createtables.sql script.  

It adds two of the newly added project meta data fields, 'nav_mode' and 'theme'.

Cheers,
- noah
