### PR TITLE
fix typo in sql

### DIFF
--- a/src/main/resources/tels/wise4-createtables.sql
+++ b/src/main/resources/tels/wise4-createtables.sql
@@ -394,8 +394,8 @@
         jnlp_fk bigint,
         metadata_fk bigint unique,
         run_fk bigint unique,
-        isDeleted` bit(1) DEFAULT b'0',
-	    `dateDeleted` timestamp NULL DEFAULT NULL,
+        isDeleted bit(1) DEFAULT b'0',
+        dateDeleted timestamp NULL DEFAULT NULL,
         primary key (id)
     ) engine=MyISAM;
 


### PR DESCRIPTION
Hey,

in trying to recreate our local portal from WISE-Community/WISE-Portal master we encountered an error.  Seems like a typo in the create tables sql.

This patch fixed our troubles.
- Noah
